### PR TITLE
enumをC89に対応させる

### DIFF
--- a/my_mod/cmd_def.py
+++ b/my_mod/cmd_def.py
@@ -225,6 +225,8 @@ typedef enum
     output += body
 
     output += '''
+
+  BC_ID_MAX    // BCT 自体のサイズは BCT_MAX_BLOCKS で規定
 } BC_DEFAULT_ID;
 
 void BC_load_defaults(void);


### PR DESCRIPTION
## 概要
enumをC89に対応させる

## Issue
- https://github.com/ut-issl/c2a-core/pull/105 で必要になった

## 詳細
enum最後の列挙子はカンマをつけてはいけない
