### PR TITLE
TlmDefで一時変数を使えるようにするためのスクリプト側の更新

### DIFF
--- a/my_mod/load_db.py
+++ b/my_mod/load_db.py
@@ -69,8 +69,8 @@ def LoadTlmCSV_(tlm_db_path, db_prefix):
             sheet = [row for row in reader]
             # pprint.pprint(sheet)
             # print(sheet)
-            tlm_id = sheet[1][2]        # テレメIDを取得．マジックナンバーで指定してしまってる．
-            raw_local_vars =  sheet[1][3].replace("%%", "").split("##")     # ローカル変数を取得．マジックナンバーで指定してしまってる．
+            tlm_id = sheet[1][2]        # FIXME: テレメIDを取得．マジックナンバーで指定してしまってる．
+            raw_local_vars =  sheet[1][3].replace("%%", "").split("##")     # FIXME: ローカル変数を取得．マジックナンバーで指定してしまってる．
             local_vars = []
             for raw_local_var in raw_local_vars:
                 local_var = raw_local_var.strip()

--- a/my_mod/load_db.py
+++ b/my_mod/load_db.py
@@ -69,8 +69,14 @@ def LoadTlmCSV_(tlm_db_path, db_prefix):
             sheet = [row for row in reader]
             # pprint.pprint(sheet)
             # print(sheet)
-            tlm_id = sheet[1][2]      # テレメIDを取得．マジックナンバーで指定してしまってる．
-            tlm_db.append({'tlm_id': tlm_id, 'tlm_name': tlm_name, 'data': sheet})
+            tlm_id = sheet[1][2]        # テレメIDを取得．マジックナンバーで指定してしまってる．
+            raw_local_vars =  sheet[1][3].replace("%%", "").split("##")     # ローカル変数を取得．マジックナンバーで指定してしまってる．
+            local_vars = []
+            for raw_local_var in raw_local_vars:
+                local_var = raw_local_var.strip()
+                if len(local_var) > 0:
+                    local_vars.append(local_var)
+            tlm_db.append({'tlm_id': tlm_id, 'tlm_name': tlm_name, 'local_vars': local_vars, 'data': sheet})
             # tlm_db.append({'tlm_id': tlm_id, 'tlm_name': tlm_name, 'data': 1})
 
     tlm_db.sort(key=lambda x: x['tlm_id'])

--- a/my_mod/tlm_def.py
+++ b/my_mod/tlm_def.py
@@ -91,6 +91,10 @@ def GenerateTlmDef(settings, tlm_db, other_obc_dbs):
         body_c += "\n"
         body_c += "static int Tlm_" + tlm['tlm_name'].upper() + "_(unsigned char* contents, int max_len)\n"
         body_c += "{\n"
+        for local_var in tlm['local_vars']:
+            body_c += "  " + local_var + "\n"
+        if len(tlm['local_vars']) > 0:
+            body_c += "\n"
         body_c += "  if (" + str(max_pos) + " > max_len) return TF_TOO_SHORT_LEN;\n"
         body_c += "\n"
         body_c += "#ifndef BUILD_SETTINGS_FAST_BUILD\n"


### PR DESCRIPTION
## 概要
TlmDefで一時変数を使えるようにするためのスクリプト側の更新

## Issue
- https://github.com/ut-issl/c2a-core/issues/140
- DB側の更新: https://github.com/ut-issl/tlm-cmd-db/pull/3

## 詳細
issue参照

## 検証結果
- https://github.com/ut-issl/c2a-core/pull/142 の C2A Core 側のPRにて検証する
