### PR TITLE
単一OBCの場合でも，TLM IDとして使える定義域をチェックするように

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ $ python GenerateC2ACode.py
   "c2a_root_dir" : "../../c2a/src/",
   # TlmCmdDBのファイル名の接頭辞
   "db_prefix" : "SAMPLE_MOBC",
+  # TLM ID の定義域
+  "tlm_id_range" : ["0x00", "0x100"],
   # 出力ファイルのエンコーディング
   "output_file_encoding" : "utf-8",
   # GSTOS用sibファイルを生成するか？ 0/1
@@ -48,13 +50,13 @@ $ python GenerateC2ACode.py
       # コードを生成するか？
       "is_enable" : 1,
       "db_prefix" : "SAMPLE_AOBC",
+      "tlm_id_range" : ["0x90", "0xc0"],
       # DBがあるディレクトリへのパス（絶対でも相対でもOK）
       "db_path" : "../../c2a_sample_aobc/src/src_user/Settings/TlmCmd/DataBase/",
       "driver_path" : "Aocs/",
       "driver_type" : "AOBC_Driver",
       "driver_name" : "aobc",
-      "code_when_tlm_not_found" : "aobc_driver->info.comm.rx_err_code = AOBC_RX_ERR_CODE_TLM_NOT_FOUND;",
-      "tlm_id_range" : ["0x90", "0xc0"]
+      "code_when_tlm_not_found" : "aobc_driver->info.comm.rx_err_code = AOBC_RX_ERR_CODE_TLM_NOT_FOUND;"
     },
     {
       # OBC名
@@ -63,13 +65,13 @@ $ python GenerateC2ACode.py
       "is_enable" : 1,
       "db_prefix" : "SAMPLE_TOBC",
       # DBがあるディレクトリへのパス（絶対でも相対でもOK）
+      "tlm_id_range" : ["0xc0", "0xf0"],
       "db_path" : ""../../c2a_sample_tobc/src/src_user/Settings/TlmCmd/DataBase/",
       "tlm_max_contents_len" : 512,
       "driver_path" : "Thermal/",
       "driver_type" : "TOBC_Driver",
       "driver_name" : "tobc",
-      "code_when_tlm_not_found" : "tobc_driver->info.comm.rx_err_code = TOBC_RX_ERR_CODE_TLM_NOT_FOUND;",
-      "tlm_id_range" : ["0xc0", "0xf0"]
+      "code_when_tlm_not_found" : "tobc_driver->info.comm.rx_err_code = TOBC_RX_ERR_CODE_TLM_NOT_FOUND;"
     }
   ]
 }

--- a/my_mod/load_db.py
+++ b/my_mod/load_db.py
@@ -4,6 +4,7 @@ DB読み込み
 """
 
 import os
+import sys
 import csv
 import re           # 正規表現
 import pprint
@@ -41,7 +42,7 @@ def LoadCmdCSV_(cmd_db_path, db_prefix):
 def LoadTlmDb(settings):
     tlm_db_path = settings["c2a_root_dir"] + r"src_user/Settings/TlmCmd/DataBase/TLM_DB/calced_data/"
 
-    tlm_db = LoadTlmCSV_(tlm_db_path, settings["db_prefix"])
+    tlm_db = LoadTlmCSV_(tlm_db_path, settings["db_prefix"], settings["tlm_id_range"])
 
     other_obc_dbs = {}
     if settings["is_main_obc"]:
@@ -52,7 +53,7 @@ def LoadTlmDb(settings):
     return {'tlm': tlm_db, 'other_obc': other_obc_dbs}
 
 
-def LoadTlmCSV_(tlm_db_path, db_prefix):
+def LoadTlmCSV_(tlm_db_path, db_prefix, tlm_id_range):
     tlm_names = [file for file in os.listdir(tlm_db_path) if file.endswith(".csv")]
     regex = r"^" + db_prefix + "_TLM_DB_"
     tlm_names = [re.sub(regex, "", file) for file in tlm_names]
@@ -70,6 +71,9 @@ def LoadTlmCSV_(tlm_db_path, db_prefix):
             # pprint.pprint(sheet)
             # print(sheet)
             tlm_id = sheet[1][2]        # FIXME: テレメIDを取得．マジックナンバーで指定してしまってる．
+            if not int(tlm_id_range[0], 0) <= int(tlm_id, 0) < int(tlm_id_range[1], 0):
+                print("Error: TLM ID is invalid at " + db_prefix + "_TLM_DB_" + tlm_name + ".csv", file=sys.stderr)
+                sys.exit(1)
             raw_local_vars =  sheet[1][3].replace("%%", "").split("##")     # FIXME: ローカル変数を取得．マジックナンバーで指定してしまってる．
             local_vars = []
             for raw_local_var in raw_local_vars:
@@ -109,7 +113,7 @@ def LoadOtherObcTlm(settings):
             continue
         tlm_db_path = settings["other_obc_data"][i]["db_path"] + r"TLM_DB/calced_data/"
 
-        tlm_db = LoadTlmCSV_(tlm_db_path, settings["other_obc_data"][i]["db_prefix"])
+        tlm_db = LoadTlmCSV_(tlm_db_path, settings["other_obc_data"][i]["db_prefix"], settings["other_obc_data"][i]["tlm_id_range"])
         other_obc_dbs[settings["other_obc_data"][i]["name"]] = tlm_db
 
     # pprint.pprint(other_obc_dbs)

--- a/settings.json
+++ b/settings.json
@@ -1,6 +1,7 @@
 {
   "c2a_root_dir" : "../../c2a/src/",
   "db_prefix" : "SAMPLE_MOBC",
+  "tlm_id_range" : ["0x00", "0x100"],
   "output_file_encoding" : "utf-8",
   "is_generated_sib" : 0,
   "header_len" : 13,
@@ -10,25 +11,25 @@
       "name" : "AOBC",
       "is_enable" : 1,
       "db_prefix" : "SAMPLE_AOBC",
+      "tlm_id_range" : ["0x90", "0xc0"],
       "db_path" : "C:/c2a_sample_aobc/src/src_user/Settings/TlmCmd/DataBase/",
       "tlm_max_contents_len" : 512,
       "driver_path" : "Aocs/",
       "driver_type" : "AOBC_Driver",
       "driver_name" : "aobc_driver",
-      "code_when_tlm_not_found" : "aobc_driver->info.comm.rx_err_code = AOBC_RX_ERR_CODE_TLM_NOT_FOUND;",
-      "tlm_id_range" : ["0x90", "0xc0"]
+      "code_when_tlm_not_found" : "aobc_driver->info.comm.rx_err_code = AOBC_RX_ERR_CODE_TLM_NOT_FOUND;"
     },
     {
       "name" : "TOBC",
       "is_enable" : 1,
       "db_prefix" : "SAMPLE_TOBC",
+      "tlm_id_range" : ["0xc0", "0xf0"],
       "db_path" : "C:/c2a_sample_tobc/src/src_user/Settings/TlmCmd/DataBase/",
       "tlm_max_contents_len" : 512,
       "driver_path" : "Thermal/",
       "driver_type" : "TOBC_Driver",
       "driver_name" : "tobc_driver",
-      "code_when_tlm_not_found" : "tobc_driver->info.comm.rx_err_code = TOBC_RX_ERR_CODE_TLM_NOT_FOUND;",
-      "tlm_id_range" : ["0xc0", "0xf0"]
+      "code_when_tlm_not_found" : "tobc_driver->info.comm.rx_err_code = TOBC_RX_ERR_CODE_TLM_NOT_FOUND;"
     }
   ]
 }


### PR DESCRIPTION
## 概要
単一OBCの場合でも，TLM IDとして使える定義域をチェックするように

## Issue
NA

## 詳細
TLM IDのバリデーションを追加した

## 検証結果
C2A Coreや2nd OBCのあるISSL MOBC環境で試した．