### PR TITLE
local vars で カンマがExcelの仕様で@@に置換されてしまう問題を修正

### DIFF
--- a/my_mod/load_db.py
+++ b/my_mod/load_db.py
@@ -89,7 +89,7 @@ def LoadTlmCSV_(tlm_db_path, db_prefix, tlm_id_range):
             )  # FIXME: ローカル変数を取得．マジックナンバーで指定してしまってる．
             local_vars = []
             for raw_local_var in raw_local_vars:
-                local_var = raw_local_var.strip()
+                local_var = raw_local_var.strip().replace("@@", ",")
                 if len(local_var) > 0:
                     local_vars.append(local_var)
             tlm_db.append(


### PR DESCRIPTION
## 概要
local vars で カンマがExcelの仕様で@@に置換されてしまう問題を修正

## Issue
N/A

## 詳細
local vars の中のカンマがExcelの仕様で@@に置換されてしまうのでreplace を追加した

## 検証結果
手元で通った

## 影響範囲
小
