### PR TITLE
TLM生成関数の返り値を int から TF_ACK にする

### DIFF
--- a/my_mod/tlm_buffer.py
+++ b/my_mod/tlm_buffer.py
@@ -114,13 +114,12 @@ def GenerateTlmBuffer(settings, other_obc_dbs):
             + ");\n"
         )
         body_h += "\n"
-        body_h += "// FIXME: TF_ACK になおす！\n"
         body_h += (
-            "int {_obc_name_upper}_pick_up_tlm_buffer(const "
+            "TF_TLM_FUNC_ACK {_obc_name_upper}_pick_up_tlm_buffer(const "
             + driver_type
             + "* "
             + driver_name
-            + ", {_obc_name_upper}_TLM_CODE tlm_id, uint8_t* packet, int max_len);\n"
+            + ", {_obc_name_upper}_TLM_CODE tlm_id, uint8_t* packet, uint16_t* len, uint16_t max_len);\n"
         )
 
         body_c += (
@@ -309,30 +308,29 @@ def GenerateTlmBuffer(settings, other_obc_dbs):
             body_c += "\n"
 
         body_c += (
-            "int {_obc_name_upper}_pick_up_tlm_buffer(const "
+            "TF_TLM_FUNC_ACK {_obc_name_upper}_pick_up_tlm_buffer(const "
             + driver_type
             + "* "
             + driver_name
-            + ", {_obc_name_upper}_TLM_CODE tlm_id, uint8_t* packet, int max_len)\n"
+            + ", {_obc_name_upper}_TLM_CODE tlm_id, uint8_t* packet, uint16_t* len, uint16_t max_len)\n"
         )
         body_c += "{{\n"
         body_c += "  const CommonTlmPacket* buffered_packet;\n"
-        body_c += "  uint16_t packet_len;\n"
         body_c += "\n"
-        body_c += "  if (tlm_id >= {_obc_name_upper}_MAX_TLM_NUM) return TF_NOT_DEFINED;\n"
+        body_c += "  if (tlm_id >= {_obc_name_upper}_MAX_TLM_NUM) return TF_TLM_FUNC_ACK_NOT_DEFINED;\n"
         body_c += (
             "  if ("
             + driver_name
-            + "->tlm_buffer.tlm[tlm_id].is_null_packet) return TF_NULL_PACKET;\n"
+            + "->tlm_buffer.tlm[tlm_id].is_null_packet) return TF_TLM_FUNC_ACK_NULL_PACKET;\n"
         )
         body_c += "\n"
         body_c += "  buffered_packet = &(" + driver_name + "->tlm_buffer.tlm[tlm_id].packet);\n"
-        body_c += "  packet_len = CTP_get_packet_len(buffered_packet);\n"
+        body_c += "  *len = CTP_get_packet_len(buffered_packet);\n"
         body_c += "\n"
-        body_c += "  if (packet_len > max_len) return TF_TOO_SHORT_LEN;\n"
+        body_c += "  if (*len > max_len) return TF_TLM_FUNC_ACK_TOO_SHORT_LEN;\n"
         body_c += "\n"
-        body_c += "  memcpy(packet, &buffered_packet->packet, (size_t)packet_len);\n"
-        body_c += "  return packet_len;\n"
+        body_c += "  memcpy(packet, &buffered_packet->packet, (size_t)(*len));\n"
+        body_c += "  return TF_TLM_FUNC_ACK_SUCCESS;\n"
         body_c += "}}\n"
         body_c += "\n"
 

--- a/my_mod/tlm_buffer.py
+++ b/my_mod/tlm_buffer.py
@@ -317,7 +317,9 @@ def GenerateTlmBuffer(settings, other_obc_dbs):
         body_c += "{{\n"
         body_c += "  const CommonTlmPacket* buffered_packet;\n"
         body_c += "\n"
-        body_c += "  if (tlm_id >= {_obc_name_upper}_MAX_TLM_NUM) return TF_TLM_FUNC_ACK_NOT_DEFINED;\n"
+        body_c += (
+            "  if (tlm_id >= {_obc_name_upper}_MAX_TLM_NUM) return TF_TLM_FUNC_ACK_NOT_DEFINED;\n"
+        )
         body_c += (
             "  if ("
             + driver_name

--- a/my_mod/tlm_def.py
+++ b/my_mod/tlm_def.py
@@ -15,10 +15,10 @@ def GenerateTlmDef(settings, tlm_db, other_obc_dbs):
     body_c = ""
     body_h = ""
 
-    # "static int OBC_(uint8_t* packet, int max_len);"
+    # "static TF_TLM_FUNC_ACK OBC_(uint8_t* packet, uint16_t* len, uint16_t max_len);"
     # "  OBC_ID = 0x00,"
     for tlm in tlm_db:
-        body_c += "static int Tlm_" + tlm["tlm_name"].upper() + "_(uint8_t* packet, int max_len);\n"
+        body_c += "static TF_TLM_FUNC_ACK Tlm_" + tlm["tlm_name"].upper() + "_(uint8_t* packet, uint16_t* len, uint16_t max_len);\n"
         body_h += "  Tlm_CODE_" + tlm["tlm_name"].upper() + " = " + tlm["tlm_id"] + ",\n"
 
     if settings["is_main_obc"]:
@@ -95,19 +95,20 @@ def GenerateTlmDef(settings, tlm_db, other_obc_dbs):
             func_code += "(&packet[" + str(pos) + "], " + code + ");\n"
 
         body_c += "\n"
-        body_c += "static int Tlm_" + tlm["tlm_name"].upper() + "_(uint8_t* packet, int max_len)\n"
+        body_c += "static TF_TLM_FUNC_ACK Tlm_" + tlm["tlm_name"].upper() + "_(uint8_t* packet, uint16_t* len, uint16_t max_len)\n"
         body_c += "{\n"
         for local_var in tlm["local_vars"]:
             body_c += "  " + local_var + "\n"
         if len(tlm["local_vars"]) > 0:
             body_c += "\n"
-        body_c += "  if (" + str(max_pos) + " > max_len) return TF_TOO_SHORT_LEN;\n"
+        body_c += "  if (" + str(max_pos) + " > max_len) return TF_TLM_FUNC_ACK_TOO_SHORT_LEN;\n"
         body_c += "\n"
         body_c += "#ifndef BUILD_SETTINGS_FAST_BUILD\n"
         body_c += func_code
         body_c += "#endif\n"
         body_c += "\n"
-        body_c += "  return " + str(max_pos) + ";\n"
+        body_c += "  *len = " + str(max_pos) + ";\n"
+        body_c += "  return TF_TLM_FUNC_ACK_SUCCESS;\n"
         body_c += "}\n"
 
     if settings["is_main_obc"]:
@@ -133,7 +134,7 @@ def GetTlmDefCOfOtherObcFunDef_(settings, tlm_db, other_obc_dbs):
         temp_c += "// {_obc_name_upper} TLM\n"
         for tlm in oter_obc_tlm_db:
             temp_c += (
-                "static int Tlm_" + tlm["tlm_name"].upper() + "_(uint8_t* packet, int max_len);\n"
+                "static TF_TLM_FUNC_ACK Tlm_" + tlm["tlm_name"].upper() + "_(uint8_t* packet, uint16_t* len, uint16_t max_len);\n"
             )
 
         body_c += temp_c.format(
@@ -192,14 +193,14 @@ def GetTlmDefCOfOtherObcFunBody_(settings, tlm_db, other_obc_dbs):
             tlm_name_upper = tlm_name.upper()
             # tlm_name_lower = tlm_name.lower()
             temp_c += "\n"
-            temp_c += "static int Tlm_" + tlm_name_upper + "_(uint8_t* packet, int max_len)\n"
+            temp_c += "static TF_TLM_FUNC_ACK Tlm_" + tlm_name_upper + "_(uint8_t* packet, uint16_t* len, uint16_t max_len)\n"
             temp_c += "{{\n"
             temp_c += (
                 "  return {_obc_name_upper}_pick_up_tlm_buffer("
                 + driver_name
                 + ", {_obc_name_upper}_Tlm_CODE_"
                 + tlm_name_upper
-                + ", packet, max_len);\n"
+                + ", packet, len, max_len);\n"
             )
             temp_c += "}}\n"
 

--- a/my_mod/tlm_def.py
+++ b/my_mod/tlm_def.py
@@ -18,7 +18,11 @@ def GenerateTlmDef(settings, tlm_db, other_obc_dbs):
     # "static TF_TLM_FUNC_ACK OBC_(uint8_t* packet, uint16_t* len, uint16_t max_len);"
     # "  OBC_ID = 0x00,"
     for tlm in tlm_db:
-        body_c += "static TF_TLM_FUNC_ACK Tlm_" + tlm["tlm_name"].upper() + "_(uint8_t* packet, uint16_t* len, uint16_t max_len);\n"
+        body_c += (
+            "static TF_TLM_FUNC_ACK Tlm_"
+            + tlm["tlm_name"].upper()
+            + "_(uint8_t* packet, uint16_t* len, uint16_t max_len);\n"
+        )
         body_h += "  Tlm_CODE_" + tlm["tlm_name"].upper() + " = " + tlm["tlm_id"] + ",\n"
 
     if settings["is_main_obc"]:
@@ -95,7 +99,11 @@ def GenerateTlmDef(settings, tlm_db, other_obc_dbs):
             func_code += "(&packet[" + str(pos) + "], " + code + ");\n"
 
         body_c += "\n"
-        body_c += "static TF_TLM_FUNC_ACK Tlm_" + tlm["tlm_name"].upper() + "_(uint8_t* packet, uint16_t* len, uint16_t max_len)\n"
+        body_c += (
+            "static TF_TLM_FUNC_ACK Tlm_"
+            + tlm["tlm_name"].upper()
+            + "_(uint8_t* packet, uint16_t* len, uint16_t max_len)\n"
+        )
         body_c += "{\n"
         for local_var in tlm["local_vars"]:
             body_c += "  " + local_var + "\n"
@@ -134,7 +142,9 @@ def GetTlmDefCOfOtherObcFunDef_(settings, tlm_db, other_obc_dbs):
         temp_c += "// {_obc_name_upper} TLM\n"
         for tlm in oter_obc_tlm_db:
             temp_c += (
-                "static TF_TLM_FUNC_ACK Tlm_" + tlm["tlm_name"].upper() + "_(uint8_t* packet, uint16_t* len, uint16_t max_len);\n"
+                "static TF_TLM_FUNC_ACK Tlm_"
+                + tlm["tlm_name"].upper()
+                + "_(uint8_t* packet, uint16_t* len, uint16_t max_len);\n"
             )
 
         body_c += temp_c.format(
@@ -193,7 +203,11 @@ def GetTlmDefCOfOtherObcFunBody_(settings, tlm_db, other_obc_dbs):
             tlm_name_upper = tlm_name.upper()
             # tlm_name_lower = tlm_name.lower()
             temp_c += "\n"
-            temp_c += "static TF_TLM_FUNC_ACK Tlm_" + tlm_name_upper + "_(uint8_t* packet, uint16_t* len, uint16_t max_len)\n"
+            temp_c += (
+                "static TF_TLM_FUNC_ACK Tlm_"
+                + tlm_name_upper
+                + "_(uint8_t* packet, uint16_t* len, uint16_t max_len)\n"
+            )
             temp_c += "{{\n"
             temp_c += (
                 "  return {_obc_name_upper}_pick_up_tlm_buffer("


### PR DESCRIPTION
## 概要
TLM生成関数の返り値を int から TF_ACK にする

## Issue
- https://github.com/ut-issl/c2a-core/issues/227

## 詳細
- https://github.com/ut-issl/c2a-core/pull/288 のtool側対応

## 検証結果
- https://github.com/ut-issl/c2a-core/pull/288 で検証

## 影響範囲
非互換なので，このあと release を打つ
