### PR TITLE
Draft: ある c2a_user のための対応ブランチ

### DIFF
--- a/my_mod/load_db.py
+++ b/my_mod/load_db.py
@@ -12,7 +12,7 @@ import re  # 正規表現
 
 
 def LoadCmdDb(settings):
-    cmd_db_path = settings["c2a_root_dir"] + r"src_user/Settings/TlmCmd/DataBase/CMD_DB/"
+    cmd_db_path = settings["db_path"] + r"CMD_DB/"
 
     sgc_db, bct_db = LoadCmdCSV_(
         cmd_db_path, settings["db_prefix"], settings["input_file_encoding"]
@@ -44,9 +44,7 @@ def LoadCmdCSV_(cmd_db_path, db_prefix, encoding):
 
 
 def LoadTlmDb(settings):
-    tlm_db_path = (
-        settings["c2a_root_dir"] + r"src_user/Settings/TlmCmd/DataBase/TLM_DB/calced_data/"
-    )
+    tlm_db_path = settings["db_path"] + r"TLM_DB/calced_data/"
 
     tlm_db = LoadTlmCSV_(
         tlm_db_path,

--- a/my_mod/tlm_buffer.py
+++ b/my_mod/tlm_buffer.py
@@ -8,6 +8,8 @@ import sys
 # from collections import OrderedDict
 # import pprint
 
+INVALID_START_CHARS = [str(0), str(1), str(2), str(3), str(4), str(5), str(6), str(7), str(8), str(9)]
+
 
 def GenerateTlmBuffer(settings, other_obc_dbs):
     DATA_START_ROW = 8
@@ -259,6 +261,9 @@ def GenerateTlmBuffer(settings, other_obc_dbs):
 
                 # name_tree = name.lower().split(".")[2:]     # OBC名.テレメ名.HOGE.FUGA を想定
                 name_tree = name.lower().split(".")
+                for idx, item in enumerate(name_tree):
+                    if item[0] in INVALID_START_CHARS:
+                        name_tree[idx] = "_" + item
                 name_path = ".".join(name_tree)
                 var_name = driver_name + "->tlm_data." + tlm_name_lower + "." + name_path
                 if is_compression:
@@ -493,6 +498,8 @@ def SetStructTree_(dict, path, val, sep="/"):
             return 1  # err
         if len(path_list) == 1:
             key = path_list[0]
+            if key[0] in INVALID_START_CHARS:
+                key = "_" + key
             if key in dict:
                 return 1  # 上書きエラー
             else:
@@ -500,6 +507,8 @@ def SetStructTree_(dict, path, val, sep="/"):
                 return 0
         else:
             key = path_list[0]
+            if key[0] in INVALID_START_CHARS:
+                key = "_" + key
             if key not in dict:
                 dict[key] = {}
             return _(dict[key], path_list[1:], val, sep)

--- a/my_mod/tlm_buffer.py
+++ b/my_mod/tlm_buffer.py
@@ -8,7 +8,18 @@ import sys
 # from collections import OrderedDict
 # import pprint
 
-INVALID_START_CHARS = [str(0), str(1), str(2), str(3), str(4), str(5), str(6), str(7), str(8), str(9)]
+INVALID_START_CHARS = [
+    str(0),
+    str(1),
+    str(2),
+    str(3),
+    str(4),
+    str(5),
+    str(6),
+    str(7),
+    str(8),
+    str(9),
+]
 
 
 def GenerateTlmBuffer(settings, other_obc_dbs):

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,6 @@
 {
   "c2a_root_dir" : "../../c2a/src/",
+  "db_path" : "../../c2a/database/",
   "db_prefix" : "SAMPLE_MOBC",
   "tlm_id_range" : ["0x00", "0x100"],
   "input_file_encoding" : "utf-8",


### PR DESCRIPTION
## 概要
ある c2a_user のための対応ブランチ

## Issue
N/A

## 詳細
以下を修正している
- db path を settings.json で指定できるようにした
- sub OBC に数字から始まるテレメ名があると、tlm_buf などの変数名も数字から始まってしまいバグってしまう。数字から始まる場合は "_" を前に足すことで一時的に対応

このユーザー部が core update を長らくかけていなくて対応が大変なので、ひとまずこのブランチで応急処置している。core update かけたらちゃんとPR出す

## 検証結果
CI

## 影響範囲
XX系の動作がガラッと変わる，とか．

## 補足
何かあれば
