### PR TITLE
Tlm Cmd DB の UTF-8 化 にともなう更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ $ python GenerateC2ACode.py
   "db_prefix" : "SAMPLE_MOBC",
   # TLM ID の定義域
   "tlm_id_range" : ["0x00", "0x100"],
+  # 入力 Tlm Cmd DB のエンコーディング
+  "input_file_encoding" : "utf-8",
   # 出力ファイルのエンコーディング
   "output_file_encoding" : "utf-8",
   # MOBCか？（他のOBCのtlm/cmdを取りまとめるか？） 0/1
@@ -47,6 +49,7 @@ $ python GenerateC2ACode.py
       "is_enable" : 1,
       "db_prefix" : "SAMPLE_AOBC",
       "tlm_id_range" : ["0x90", "0xc0"],
+      "input_file_encoding" : "utf-8",
       # DBがあるディレクトリへのパス（絶対でも相対でもOK）
       "db_path" : "../../c2a_sample_aobc/src/src_user/Settings/TlmCmd/DataBase/",
       # MOBC で保持するテレメの TLM ID の最大値（＝テレメ種類数）
@@ -63,6 +66,7 @@ $ python GenerateC2ACode.py
       "is_enable" : 1,
       "db_prefix" : "SAMPLE_TOBC",
       "tlm_id_range" : ["0xc0", "0xf0"],
+      "input_file_encoding" : "utf-8",
       # DBがあるディレクトリへのパス（絶対でも相対でもOK）
       "db_path" : ""../../c2a_sample_tobc/src/src_user/Settings/TlmCmd/DataBase/",
       # MOBC で保持するテレメの TLM ID の最大値（＝テレメ種類数）

--- a/my_mod/load_db.py
+++ b/my_mod/load_db.py
@@ -14,7 +14,9 @@ import re  # 正規表現
 def LoadCmdDb(settings):
     cmd_db_path = settings["c2a_root_dir"] + r"src_user/Settings/TlmCmd/DataBase/CMD_DB/"
 
-    sgc_db, bct_db = LoadCmdCSV_(cmd_db_path, settings["db_prefix"], settings["input_file_encoding"])
+    sgc_db, bct_db = LoadCmdCSV_(
+        cmd_db_path, settings["db_prefix"], settings["input_file_encoding"]
+    )
 
     other_obc_dbs = {}
     if settings["is_main_obc"]:
@@ -46,7 +48,12 @@ def LoadTlmDb(settings):
         settings["c2a_root_dir"] + r"src_user/Settings/TlmCmd/DataBase/TLM_DB/calced_data/"
     )
 
-    tlm_db = LoadTlmCSV_(tlm_db_path, settings["db_prefix"], settings["tlm_id_range"], settings["input_file_encoding"])
+    tlm_db = LoadTlmCSV_(
+        tlm_db_path,
+        settings["db_prefix"],
+        settings["tlm_id_range"],
+        settings["input_file_encoding"],
+    )
 
     other_obc_dbs = {}
     if settings["is_main_obc"]:
@@ -109,7 +116,11 @@ def LoadOtherObcCmd_(settings):
         if not settings["other_obc_data"][i]["is_enable"]:
             continue
         cmd_db_path = settings["other_obc_data"][i]["db_path"] + r"CMD_DB/"
-        sgc_db, bct_db = LoadCmdCSV_(cmd_db_path, settings["other_obc_data"][i]["db_prefix"], settings["other_obc_data"][i]["input_file_encoding"])
+        sgc_db, bct_db = LoadCmdCSV_(
+            cmd_db_path,
+            settings["other_obc_data"][i]["db_prefix"],
+            settings["other_obc_data"][i]["input_file_encoding"],
+        )
         # other_obc_dbs.append(sgc_db)
         other_obc_dbs[settings["other_obc_data"][i]["name"]] = sgc_db
         # print(i)
@@ -131,7 +142,7 @@ def LoadOtherObcTlm(settings):
             tlm_db_path,
             settings["other_obc_data"][i]["db_prefix"],
             settings["other_obc_data"][i]["tlm_id_range"],
-            settings["other_obc_data"][i]["input_file_encoding"]
+            settings["other_obc_data"][i]["input_file_encoding"],
         )
         other_obc_dbs[settings["other_obc_data"][i]["name"]] = tlm_db
 

--- a/my_mod/load_db.py
+++ b/my_mod/load_db.py
@@ -14,7 +14,7 @@ import re  # 正規表現
 def LoadCmdDb(settings):
     cmd_db_path = settings["c2a_root_dir"] + r"src_user/Settings/TlmCmd/DataBase/CMD_DB/"
 
-    sgc_db, bct_db = LoadCmdCSV_(cmd_db_path, settings["db_prefix"])
+    sgc_db, bct_db = LoadCmdCSV_(cmd_db_path, settings["db_prefix"], settings["input_file_encoding"])
 
     other_obc_dbs = {}
     if settings["is_main_obc"]:
@@ -27,14 +27,14 @@ def LoadCmdDb(settings):
     return {"sgc": sgc_db, "bct": bct_db, "other_obc": other_obc_dbs}
 
 
-def LoadCmdCSV_(cmd_db_path, db_prefix):
+def LoadCmdCSV_(cmd_db_path, db_prefix, encoding):
     sgc_db_path = cmd_db_path + db_prefix + "_CMD_DB_CMD_DB.csv"  # single cmd
     bct_db_path = cmd_db_path + db_prefix + "_CMD_DB_BCT.csv"  # block cmd table
 
-    with open(sgc_db_path, mode="r", encoding="shift_jis") as fh:
+    with open(sgc_db_path, mode="r", encoding=encoding) as fh:
         reader = csv.reader(fh)
         sgc_db = [row for row in reader]
-    with open(bct_db_path, mode="r", encoding="shift_jis") as fh:
+    with open(bct_db_path, mode="r", encoding=encoding) as fh:
         reader = csv.reader(fh)
         bct_db = [row for row in reader]
 
@@ -46,7 +46,7 @@ def LoadTlmDb(settings):
         settings["c2a_root_dir"] + r"src_user/Settings/TlmCmd/DataBase/TLM_DB/calced_data/"
     )
 
-    tlm_db = LoadTlmCSV_(tlm_db_path, settings["db_prefix"], settings["tlm_id_range"])
+    tlm_db = LoadTlmCSV_(tlm_db_path, settings["db_prefix"], settings["tlm_id_range"], settings["input_file_encoding"])
 
     other_obc_dbs = {}
     if settings["is_main_obc"]:
@@ -57,7 +57,7 @@ def LoadTlmDb(settings):
     return {"tlm": tlm_db, "other_obc": other_obc_dbs}
 
 
-def LoadTlmCSV_(tlm_db_path, db_prefix, tlm_id_range):
+def LoadTlmCSV_(tlm_db_path, db_prefix, tlm_id_range, encoding):
     tlm_names = [file for file in os.listdir(tlm_db_path) if file.endswith(".csv")]
     regex = r"^" + db_prefix + "_TLM_DB_"
     tlm_names = [re.sub(regex, "", file) for file in tlm_names]
@@ -69,7 +69,7 @@ def LoadTlmCSV_(tlm_db_path, db_prefix, tlm_id_range):
 
     for tlm_name in tlm_names:
         tlm_sheet_path = tlm_db_path + db_prefix + "_TLM_DB_" + tlm_name + ".csv"
-        with open(tlm_sheet_path, mode="r", encoding="shift_jis") as fh:
+        with open(tlm_sheet_path, mode="r", encoding=encoding) as fh:
             reader = csv.reader(fh)
             sheet = [row for row in reader]
             # pprint.pprint(sheet)
@@ -109,7 +109,7 @@ def LoadOtherObcCmd_(settings):
         if not settings["other_obc_data"][i]["is_enable"]:
             continue
         cmd_db_path = settings["other_obc_data"][i]["db_path"] + r"CMD_DB/"
-        sgc_db, bct_db = LoadCmdCSV_(cmd_db_path, settings["other_obc_data"][i]["db_prefix"])
+        sgc_db, bct_db = LoadCmdCSV_(cmd_db_path, settings["other_obc_data"][i]["db_prefix"], settings["other_obc_data"][i]["input_file_encoding"])
         # other_obc_dbs.append(sgc_db)
         other_obc_dbs[settings["other_obc_data"][i]["name"]] = sgc_db
         # print(i)
@@ -131,6 +131,7 @@ def LoadOtherObcTlm(settings):
             tlm_db_path,
             settings["other_obc_data"][i]["db_prefix"],
             settings["other_obc_data"][i]["tlm_id_range"],
+            settings["other_obc_data"][i]["input_file_encoding"]
         )
         other_obc_dbs[settings["other_obc_data"][i]["name"]] = tlm_db
 

--- a/settings.json
+++ b/settings.json
@@ -2,6 +2,7 @@
   "c2a_root_dir" : "../../c2a/src/",
   "db_prefix" : "SAMPLE_MOBC",
   "tlm_id_range" : ["0x00", "0x100"],
+  "input_file_encoding" : "utf-8",
   "output_file_encoding" : "utf-8",
   "is_main_obc" : 1,
   "other_obc_data" : [
@@ -10,6 +11,7 @@
       "is_enable" : 1,
       "db_prefix" : "SAMPLE_AOBC",
       "tlm_id_range" : ["0x90", "0xc0"],
+      "input_file_encoding" : "utf-8",
       "db_path" : "C:/c2a_sample_aobc/src/src_user/Settings/TlmCmd/DataBase/",
       "max_tlm_num" : 256,
       "driver_path" : "Aocs/",
@@ -22,6 +24,7 @@
       "is_enable" : 1,
       "db_prefix" : "SAMPLE_TOBC",
       "tlm_id_range" : ["0xc0", "0xf0"],
+      "input_file_encoding" : "utf-8",
       "db_path" : "C:/c2a_sample_tobc/src/src_user/Settings/TlmCmd/DataBase/",
       "max_tlm_num" : 256,
       "driver_path" : "Thermal/",


### PR DESCRIPTION
## 概要
Tlm Cmd DB の UTF-8 化 にともなう更新

## Issue
- https://github.com/ut-issl/tlm-cmd-db/issues/14

## 詳細
- https://github.com/ut-issl/tlm-cmd-db/pull/15 にともない，input ファイルの文字コードを選択可能に

## 検証結果
- https://github.com/ut-issl/c2a-core/pull/407 で検証

## 影響範囲
- C2A本体の修正: https://github.com/ut-issl/c2a-core/pull/407
- Tool の修正: https://github.com/ut-issl/tlm-cmd-db/pull/15

## その他
- [ ] 後方互換性がなくなるので release を打つ


