### PR TITLE
Cmd_TG_FORWARD_TLM 対応

### DIFF
--- a/GenerateC2ACode.py
+++ b/GenerateC2ACode.py
@@ -38,7 +38,7 @@ def main():
 
     my_mod.cmd_def.GenerateCmdDef(settings, cmd_db["sgc"])
     my_mod.cmd_def.GenerateBctDef(settings, cmd_db["bct"])
-    my_mod.tlm_def.GenerateTlmDef(settings, tlm_db["tlm"], tlm_db["other_obc"])
+    my_mod.tlm_def.GenerateTlmDef(settings, tlm_db["tlm"])
 
     if settings["is_main_obc"]:
         my_mod.cmd_def.GenerateOtherObcCmdDef(settings, cmd_db["other_obc"])


### PR DESCRIPTION
## 概要
Cmd_TG_FORWARD_TLM 対応

## Issue
- https://github.com/ut-issl/c2a-core/issues/537
- https://github.com/ut-issl/c2a-core/issues/539
- https://github.com/ut-issl/c2a-core/issues/540

## 詳細
- これに伴い，MOBC と 2nd OBC の tlm id の重複は許可される


以下とともにマージする

- https://github.com/ut-issl/c2a-core/pull/544
- https://github.com/ut-issl/python-wings-interface/pull/32

## 検証結果
- https://github.com/ut-issl/c2a-core/pull/544 で検証

## 影響範囲
- [ ]  非互換なのでリリースを打つ