### PR TITLE
Fix relative c2a-core header include

### DIFF
--- a/my_mod/cmd_def.py
+++ b/my_mod/cmd_def.py
@@ -191,7 +191,7 @@ def OutputCmdDefC_(file_path, body, settings):
  * @brief  コマンド定義
  * @note   このコードは自動生成されています！
  */
-#include "../../src_core/TlmCmd/command_analyze.h"
+#include <src_core/TlmCmd/command_analyze.h>
 #include "command_definitions.h"
 #include "command_source.h"
 

--- a/my_mod/tlm_def.py
+++ b/my_mod/tlm_def.py
@@ -155,7 +155,7 @@ def OutputTlmDefC_(file_path, body, settings):
  * @brief  テレメトリ定義
  * @note   このコードは自動生成されています！
  */
-#include "../../src_core/TlmCmd/telemetry_frame.h"
+#include <src_core/TlmCmd/telemetry_frame.h>
 #include "telemetry_definitions.h"
 #include "telemetry_source.h"
 


### PR DESCRIPTION
## 概要
相対パスで c2a-core のヘッダを include しているのをやめる

## Issue
- https://github.com/ut-issl/c2a-core/issues/6#issuecomment-1515006485

## 詳細
現在の C2A での標準的な include の仕方に則り，`#include "../../src_core/hoge.h"` をやめ，`#include <src_core/hoge.h>` のようにする

以下とともにマージする

- https://github.com/ut-issl/c2a-core/pull/572

## 検証結果
- https://github.com/ut-issl/c2a-core/pull/572 で検証

## 影響範囲
- [ ]  非互換なのでリリースを打つ